### PR TITLE
Functions lab: Throw a meaningful exception when the vision API request fails.

### DIFF
--- a/Content/Functions/Azure Functions HOL (C#).md
+++ b/Content/Functions/Azure Functions HOL (C#).md
@@ -171,6 +171,10 @@ Once you have created an Azure Function App, you can add Azure Functions to it. 
 	    
 	    var endpoint = ConfigurationManager.AppSettings["VisionEndpoint"];
 	    var results = await client.PostAsync(endpoint + "/analyze?visualFeatures=Adult", payload);
+	    if (!results.IsSuccessStatusCode) {
+	        throw new Exception(String.Format("Vision API request failed with status {0}, response: {1}",
+	            results.StatusCode, await results.Content.ReadAsStringAsync()));
+	    }
 	    var result = await results.Content.ReadAsAsync<ImageAnalysisInfo>();
 	    return result;
 	}


### PR DESCRIPTION
I worked an older version of the Functions lab today (before 1471b0c) and chose the wrong region for the vision API, so my function failed with a NullReferenceException and it took me a while to track down the problem.  I see how that you've already addressed that pitfall by making the vision endpoint an app setting.  It may still be useful to add proper error reporting in case anything else goes wrong with the vision API.  I tested that this code throws a useful exception that shows up on the function's Monitor page in the portal when I deliberately set the wrong SubscriptionKey.

I didn't update the HTML version of the document because a quick attempt to generate it using MarkdownPad produced a ton of unrelated diffs.  I'm probably missing something.  If you'd like contributors to be able to update the HTML files, please consider documenting the proper procedure.